### PR TITLE
Use a named mutex to implement duplicate process detection.

### DIFF
--- a/IINACT/Program.cs
+++ b/IINACT/Program.cs
@@ -12,13 +12,22 @@ namespace IINACT {
         [STAThread]
         private static void Main()
         {
-            var fetchDeps = new FetchDependencies.FetchDependencies();
-            fetchDeps.GetFfxivPlugin().Wait();
-            _dependenciesDir = fetchDeps.DependenciesDir;
-            AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
-            ApplicationConfiguration.Initialize();
-            ActGlobals.oFormActMain = new FormActMain();
-            Application.Run(new Daemon());
+            using var singletoneMutex = new Mutex(true, @"Global\IINACT", out bool createdNew);
+
+            if (createdNew)
+            {
+                var fetchDeps = new FetchDependencies.FetchDependencies();
+                fetchDeps.GetFfxivPlugin().Wait();
+                _dependenciesDir = fetchDeps.DependenciesDir;
+                AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
+                ApplicationConfiguration.Initialize();
+                ActGlobals.oFormActMain = new FormActMain();
+                Application.Run(new Daemon());
+            }
+            else
+            {
+                MessageBox.Show("IINACT is already running.");
+            }
         }
 
         private static Assembly? CurrentDomain_AssemblyResolve(object? sender, ResolveEventArgs args) {


### PR DESCRIPTION
Global\ is a special prefix that is used to designate that this should be used across all sessions instead of a session specific. This may cause issues with folks that are wanting to use the RPCAP across multiple clients.

If someone wants to support that, Local\ is the appropriate named mutex. See the Microsoft docs for remarks on the naming convention.

This should work across all platforms with new enough .NET 6 and .NET 7.

https://github.com/dotnet/coreclr/pull/5030 PR reference https://github.com/dotnet/runtime/pulls?q=named+mutex to find bugs

https://learn.microsoft.com/en-us/dotnet/api/system.threading.mutex.-ctor?view=net-6.0