### PR TITLE
Add fix for Quic not loading correctly under wine.

### DIFF
--- a/FetchDependencies/FetchDependencies.cs
+++ b/FetchDependencies/FetchDependencies.cs
@@ -8,6 +8,7 @@ namespace FetchDependencies {
         public string DependenciesDir { get; }
 
         public FetchDependencies() {
+            Environment.SetEnvironmentVariable("DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP3SUPPORT", "0");
             var assemblyDir = AppDomain.CurrentDomain.BaseDirectory;
             DependenciesDir = Path.Combine(assemblyDir, "external_dependencies");
         }


### PR DESCRIPTION
As per the following issues:
https://github.com/dotnet/runtime/issues/74629
https://github.com/dotnet/runtime/issues/77420
https://github.com/dotnet/runtime/issues/82316

HttpClient (and other, older dotnet http options that depend on it) will load the msquic native library even if its not in use. This is fine as long as the native library doesn't crash on loading, which it unfortunately does on wine. There is currently no way to disable Quic specifically in order to work around this (although an option is being discussed for addition in .NET 8, see above issues). However, if HTTP/3 is disabled altogether with the environment variable: 

`DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP3SUPPORT` (See [here](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_system_net_http_))

it does in fact prevent the msquic library from loading. This lets us remove `msquic` from `WINEDLLOVERRIDES="msquic=\,mscoree=n\,b\;wpcap=n"` and load successfully. The necessary network requests from FetchDependencies and IINACT work correctly in my testing, as none of the links fetched by IINACT or any of its libraries appear to require HTTP/3 support.