### PR TITLE
Modify Socket to use SO_REUSEADDR

### DIFF
--- a/OverlayPlugin.Core/WebSocket/ServerController.cs
+++ b/OverlayPlugin.Core/WebSocket/ServerController.cs
@@ -70,6 +70,8 @@ public class ServerController
             var address = Config.WSServerIP == "*" ? IPAddress.Any : IPAddress.Parse(Config.WSServerIP);
 
             Server = new OverlayServer(address, Config.WSServerPort, Container);
+            Server.OptionReuseAddress = true;
+            
             Server.Start();
 
             OnStateChanged?.Invoke(this, new StateChangedArgs(true, false));


### PR DESCRIPTION
As discussed in the Discord, implementing SO_REUSEADDR on the socket will bind even if the previous instance is in a TIME_WAIT state. I've compiled and tested this in-game using LMeter:

`2023-03-30 20:15:02.855 -04:00 [DBG] [OverlayPlugin.Core] Overlay WebSocket session with Id 214af227-cc20-4eb5-b46c-5da18d34acd2 disconnected!`
`2023-03-30 20:15:03.783 -04:00 [DBG] [OverlayPlugin.Core] Overlay WebSocket session with Id 32231e5e-818a-422f-9802-6f26839d6be2 connected!`
`2023-03-30 20:15:03.783 -04:00 [INF] [LMeter] Successfully Established ACT Connection`
`2023-03-30 20:15:04.603 -04:00 [DBG] [OverlayPlugin.Core] Overlay WebSocket session with Id 32231e5e-818a-422f-9802-6f26839d6be2 disconnected!`
`2023-03-30 20:15:05.432 -04:00 [DBG] [OverlayPlugin.Core] Overlay WebSocket session with Id 34f74200-80e4-492b-8367-67f243d5fa0c connected!`
`2023-03-30 20:15:05.433 -04:00 [INF] [LMeter] Successfully Established ACT Connection`



I've also done the same test during combat and cannot find any issues.

It would be wise to have someone validated this on Windows and OSX as well to make sure it does not cause any issues.