### PR TITLE
Add FFXIV Chinese version (6.5) support

### DIFF
--- a/IINACT/FfxivActPluginWrapper.cs
+++ b/IINACT/FfxivActPluginWrapper.cs
@@ -77,7 +77,11 @@ public partial class FfxivActPluginWrapper : IDisposable
 
         ffxivActPlugin = new FFXIV_ACT_Plugin.FFXIV_ACT_Plugin();
         ffxivActPlugin.ConfigureIOC();
-        OpcodeManager.Instance.SetRegion(GameRegion.Global);
+        if (dalamudClientLanguage.ToString() == "ChineseSimplified") {
+            OpcodeManager.Instance.SetRegion(GameRegion.Chinese);
+        } else {
+            OpcodeManager.Instance.SetRegion(GameRegion.Global);
+        }
 
         iocContainer = ffxivActPlugin._iocContainer;
         iocContainer.Resolve<ResourceManager>().LoadResources();
@@ -143,7 +147,7 @@ public partial class FfxivActPluginWrapper : IDisposable
             Dalamud.ClientLanguage.English => Language.English,
             Dalamud.ClientLanguage.German => Language.German,
             Dalamud.ClientLanguage.French => Language.French,
-            _ => Language.English
+            _ => dalamudClientLanguage.ToString() == "ChineseSimplified" ? Language.Chinese : Language.English
         };
 
     public void Dispose()

--- a/IINACT/Plugin.cs
+++ b/IINACT/Plugin.cs
@@ -71,7 +71,7 @@ public sealed class Plugin : IDalamudPlugin
         
         var fetchDeps =
             new FetchDependencies.FetchDependencies(Version, PluginInterface.AssemblyLocation.Directory!.FullName,
-                                                    HttpClient);
+                                                    DataManager.Language.ToString() == "ChineseSimplified", HttpClient);
         
         fetchDeps.GetFfxivPlugin();
         


### PR DESCRIPTION
Since 6.5, The Chinese version of FFXIV has finally Dalamud API 9 landed. We can support both Chinese version and global version in one assembly.

Add the logic to check Chinese version of FFXIV and download Chinese version of parsing plugin. I'm using `dalamudClientLanguage.ToString() == "ChineseSimplified"` since the global version of Dalamud doesn't have the `ChineseSimplified` enum value.

Also added Chinese version's opcodes (6.5 currently) for machina, which is not available in the `ravahn/machina` repo. In the long term I'd like to move to using the opcodes from the bundled machina library rather than an own copy.