### PR TITLE
Fix dynamic fallback for non-Global regions

### DIFF
--- a/IINACT/Network/ZoneDownHookManager.cs
+++ b/IINACT/Network/ZoneDownHookManager.cs
@@ -38,7 +38,8 @@ public unsafe class ZoneDownHookManager : IDisposable
         var moduleBase = multiScanner.Module.BaseAddress;
         
         var version = GetRunningGameVersion();
-        if (VersionConstants.Constants.ContainsKey(version))
+        var isGlobal = Machina.FFXIV.Headers.Opcodes.OpcodeManager.Instance.GameRegion == Machina.FFXIV.GameRegion.Global;
+        if (isGlobal && VersionConstants.Constants.ContainsKey(version))
         {
             versionConstants = VersionConstants.ForGameVersion(version);
             unscrambler = UnscramblerFactory.ForGameVersion(version);


### PR DESCRIPTION
Only attempt to load version constants and unscrambler for Global region, preventing errors on Korean servers where these resources don't exist.